### PR TITLE
Update symfony/dependency-injection to 2.7 for service decoration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": ">=5.5",
         "behat/behat": "^3.0.12",
-        "symfony/process": "^2.0"
+        "symfony/dependency-injection": "^2.7|^3.0",
+        "symfony/process": "^2.0|^3.0"
     },
 
     "require-dev": {

--- a/src/ScenarioStateArgumentOrganiser.php
+++ b/src/ScenarioStateArgumentOrganiser.php
@@ -18,7 +18,7 @@ use ReflectionFunctionAbstract;
 /**
  * @author Rodrigue Villetard <rodrigue.villetard@gmail.com>
  */
-class ScenarioStateArgumentOrganiser implements ArgumentOrganiser
+final class ScenarioStateArgumentOrganiser implements ArgumentOrganiser
 {
     private $baseOrganiser;
     private $store;


### PR DESCRIPTION
Fix #8
- [x] Force `symfony/dependency-injection` to 2.7 to fix https://github.com/Behat/Behat/issues/914
- [x] Decorate `PregMatchArgumentOrganiser` using [service decoration](http://symfony.com/doc/current/service_container/service_decoration.html)
