### PR TITLE
Add ScenarioStateArgument annotation for method argument injection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,4 @@ install:
 
 script:
     - vendor/bin/behat
+    - vendor/bin/phpunit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,5 @@ composer install
 
 ```
 vendor/bin/behat
+vendor/bin/phpunit
 ```

--- a/README.md
+++ b/README.md
@@ -93,11 +93,10 @@ public function takeBanana()
 ### Consuming state fragments
 
 To consume state fragments provided to the scenario's state, you must add needed arguments to step's methods using
-`ScenarioStateArgument` annotation. It can be used in many ways:
+`ScenarioStateArgument` annotation. It can be used easily:
 
-- inject 1 argument from store with the exact same name: `@ScenarioStateArgument("scenarioBanana")` or `@ScenarioStateArgument(name="scenarioBanana")`
-- inject 1 argument from store changing its name: `@ScenarioStateArgument(name="scenarioBanana", argument="banana")`
-- inject multiple arguments from store: `@ScenarioStateArgument(mapping={"scenarioBanana", scenarioBonobo="bonobo"})`
+- inject argument from store with the exact same name: `@ScenarioStateArgument("scenarioBanana")` or `@ScenarioStateArgument(name="scenarioBanana")`
+- inject argument from store changing its name: `@ScenarioStateArgument(name="scenarioBanana", argument="banana")`
 
 ```php
 use Gorghoa\ScenarioStateBehatExtension\Annotation\ScenarioStateArgument;
@@ -105,7 +104,8 @@ use Gorghoa\ScenarioStateBehatExtension\Annotation\ScenarioStateArgument;
 /**
  * @When bonobo gives this banana to :monkey
  *
- * @ScenarioStateArgument(mapping={"scenarioBanana", scenarioBonobo="bonobo"})
+ * @ScenarioStateArgument("scenarioBanana")
+ * @ScenarioStateArgument(name="scenarioBonobo", argument="bonobo")
  *
  * @param string $monkey
  * @param string $scenarioBanana

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": ">=5.5",
         "behat/behat": "^3.0.12",
         "symfony/dependency-injection": "^2.7|^3.0",
-        "symfony/process": "^2.0|^3.0"
+        "symfony/process": "^2.0|^3.0",
+        "doctrine/annotations": "^1.2"
     },
 
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 
     "require-dev": {
         "phpspec/phpspec": "~2.0",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.5"
     },
 
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         checkForUnintentionallyCoveredCode="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestSize="true"
+>
+    <testsuites>
+        <testsuite name="ScenarioStateBehatExtension Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Annotation/ScenarioStateArgument.php
+++ b/src/Annotation/ScenarioStateArgument.php
@@ -17,7 +17,7 @@ namespace Gorghoa\ScenarioStateBehatExtension\Annotation;
  * @Annotation
  * @Target("METHOD")
  */
-final class ScenarioStateArgument
+class ScenarioStateArgument
 {
     /**
      * Argument name in store.
@@ -49,5 +49,21 @@ final class ScenarioStateArgument
         }
         $this->name = $options['name'];
         $this->argument = isset($options['argument']) ? $options['argument'] : $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getArgument()
+    {
+        return $this->argument;
     }
 }

--- a/src/Annotation/ScenarioStateArgument.php
+++ b/src/Annotation/ScenarioStateArgument.php
@@ -20,13 +20,6 @@ namespace Gorghoa\ScenarioStateBehatExtension\Annotation;
 final class ScenarioStateArgument
 {
     /**
-     * Map arguments from store to method arguments.
-     *
-     * @var array
-     */
-    public $mapping = [];
-
-    /**
      * Argument name in store.
      *
      * @var string
@@ -49,20 +42,12 @@ final class ScenarioStateArgument
             $options['name'] = $options['value'];
             unset($options['value']);
         }
-        if (!isset($options['mapping']) && (!isset($options['name']) || empty(trim($options['name'])))) {
+        if (!isset($options['name']) || empty(trim($options['name']))) {
             throw new \InvalidArgumentException(
                 'You must provide the store argument name in ScenarioStateArgument annotation'
             );
         }
-        if (isset($options['mapping'])) {
-            foreach ($options['mapping'] as $key => $value) {
-                if (is_int($key)) {
-                    $key = $value;
-                }
-                $this->mapping[$key] = $value;
-            }
-        } elseif (isset($options['name'])) {
-            $this->mapping[$options['name']] = isset($options['argument']) ? $options['argument'] : $options['name'];
-        }
+        $this->name = $options['name'];
+        $this->argument = isset($options['argument']) ? $options['argument'] : $this->name;
     }
 }

--- a/src/Annotation/ScenarioStateArgument.php
+++ b/src/Annotation/ScenarioStateArgument.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the ScenarioStateBehatExtension project.
+ *
+ * (c) Rodrigue Villetard <rodrigue.villetard@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gorghoa\ScenarioStateBehatExtension\Annotation;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @Annotation
+ * @Target("METHOD")
+ */
+final class ScenarioStateArgument
+{
+    /**
+     * Map arguments from store to method arguments.
+     *
+     * @var array
+     */
+    public $mapping = [];
+
+    /**
+     * Argument name in store.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * Argument name.
+     *
+     * @var string
+     */
+    public $argument;
+
+    /**
+     * @param array $options
+     */
+    public function __construct(array $options)
+    {
+        if (isset($options['value'])) {
+            $options['name'] = $options['value'];
+            unset($options['value']);
+        }
+        if (!isset($options['mapping']) && (!isset($options['name']) || empty(trim($options['name'])))) {
+            throw new \InvalidArgumentException(
+                'You must provide the store argument name in ScenarioStateArgument annotation'
+            );
+        }
+        if (isset($options['mapping'])) {
+            foreach ($options['mapping'] as $key => $value) {
+                if (is_int($key)) {
+                    $key = $value;
+                }
+                $this->mapping[$key] = $value;
+            }
+        } elseif (isset($options['name'])) {
+            $this->mapping[$options['name']] = isset($options['argument']) ? $options['argument'] : $options['name'];
+        }
+    }
+}

--- a/src/Context/Initializer/ScenarioStateInitializer.php
+++ b/src/Context/Initializer/ScenarioStateInitializer.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 /**
  * @author Rodrigue Villetard <rodrigue.villetard@gmail.com>
  */
-final class ScenarioStateInitializer implements ContextInitializer, EventSubscriberInterface
+class ScenarioStateInitializer implements ContextInitializer, EventSubscriberInterface
 {
     /**
      * @var ScenarioStateInterface

--- a/src/ScenarioStateArgumentOrganiser.php
+++ b/src/ScenarioStateArgumentOrganiser.php
@@ -50,15 +50,15 @@ final class ScenarioStateArgumentOrganiser implements ArgumentOrganiser
         $reader::addGlobalIgnoredName('When');
         $reader::addGlobalIgnoredName('Then');
 
-        if (null !== ($annotation = $reader->getMethodAnnotation($function, ScenarioStateArgument::class))) {
-            foreach ($paramsKeys as $key) {
-                if (in_array($key, $annotation->mapping)) {
-                    $key = array_search($key, $annotation->mapping);
-                    if ($store->hasStateFragment($key)) {
-                        $match[$key] = $store->getStateFragment($key);
-                        $match[strval(++$i)] = $store->getStateFragment($key);
-                    }
-                }
+        /** @var ScenarioStateArgument[] $annotations */
+        $annotations = $reader->getMethodAnnotations($function);
+        foreach ($annotations as $annotation) {
+            if ($annotation instanceof ScenarioStateArgument &&
+                in_array($annotation->argument, $paramsKeys) &&
+                $store->hasStateFragment($annotation->name)
+            ) {
+                $match[$annotation->argument] = $store->getStateFragment($annotation->name);
+                $match[strval(++$i)] = $store->getStateFragment($annotation->name);
             }
         }
 

--- a/testapp/autoload.php
+++ b/testapp/autoload.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the ScenarioStateBehatExtension project.
+ *
+ * (c) Rodrigue Villetard <rodrigue.villetard@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__.'/Gorilla.php';
+\Doctrine\Common\Annotations\AnnotationRegistry::registerFile(__DIR__.'/../src/Annotation/ScenarioStateArgument.php');

--- a/testapp/features/bootstrap/FeatureContext.php
+++ b/testapp/features/bootstrap/FeatureContext.php
@@ -9,8 +9,9 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__.'/../../Gorilla.php';
+require_once __DIR__.'/../../autoload.php';
 
+use Gorghoa\ScenarioStateBehatExtension\Annotation\ScenarioStateArgument;
 use Gorghoa\ScenarioStateBehatExtension\Context\ScenarioStateAwareContext;
 use Gorghoa\ScenarioStateBehatExtension\ScenarioStateInterface;
 
@@ -40,6 +41,8 @@ class FeatureContext implements ScenarioStateAwareContext
     /**
      * @When gives this banana to gorilla
      *
+     * @ScenarioStateArgument("scenarioBanana")
+     *
      * @param string $scenarioBanana
      */
     public function giveBananaToGorilla($scenarioBanana)
@@ -53,12 +56,14 @@ class FeatureContext implements ScenarioStateAwareContext
     /**
      * @Then the gorilla has the banana
      *
+     * @ScenarioStateArgument(mapping={"scenarioGorilla"="gorilla", "scenarioBanana"})
+     *
      * @param string  $scenarioBanana
-     * @param Gorilla $scenarioGorilla
+     * @param Gorilla $gorilla
      */
-    public function gorillaHasBanana($scenarioBanana, Gorilla $scenarioGorilla)
+    public function gorillaHasBanana($scenarioBanana, Gorilla $gorilla)
     {
         \PHPUnit_Framework_Assert::assertEquals($scenarioBanana, ['Yammy Banana']);
-        \PHPUnit_Framework_Assert::assertEquals($scenarioGorilla->getBanana(), ['Yammy Banana']);
+        \PHPUnit_Framework_Assert::assertEquals($gorilla->getBanana(), ['Yammy Banana']);
     }
 }

--- a/testapp/features/bootstrap/FeatureContext.php
+++ b/testapp/features/bootstrap/FeatureContext.php
@@ -56,7 +56,8 @@ class FeatureContext implements ScenarioStateAwareContext
     /**
      * @Then the gorilla has the banana
      *
-     * @ScenarioStateArgument(mapping={"scenarioGorilla"="gorilla", "scenarioBanana"})
+     * @ScenarioStateArgument("scenarioBanana")
+     * @ScenarioStateArgument(name="scenarioGorilla", argument="gorilla")
      *
      * @param string  $scenarioBanana
      * @param Gorilla $gorilla

--- a/tests/Annotation/ScenarioStateArgumentTest.php
+++ b/tests/Annotation/ScenarioStateArgumentTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the ScenarioStateBehatExtension project.
+ *
+ * (c) Rodrigue Villetard <rodrigue.villetard@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gorghoa\ScenarioStateBehatExtension\Annotation;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ */
+class ScenarioStateArgumentTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getArguments
+     *
+     * @param array  $arguments
+     * @param string $name
+     * @param string $argument
+     */
+    public function testWithValue(array $arguments, $name, $argument)
+    {
+        $annotation = new ScenarioStateArgument($arguments);
+        $this->assertEquals($name, $annotation->name);
+        $this->assertEquals($argument, $annotation->argument);
+    }
+
+    /**
+     * @return array
+     */
+    public function getArguments()
+    {
+        return [
+            [
+                ['value' => 'foo'],
+                'foo',
+                'foo',
+            ],
+            [
+                ['name' => 'foo'],
+                'foo',
+                'foo',
+            ],
+            [
+                ['name' => 'foo', 'argument' => 'bar'],
+                'foo',
+                'bar',
+            ],
+        ];
+    }
+}

--- a/tests/ScenarioStateArgumentOrganiserTest.php
+++ b/tests/ScenarioStateArgumentOrganiserTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the ScenarioStateBehatExtension project.
+ *
+ * (c) Rodrigue Villetard <rodrigue.villetard@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gorghoa\ScenarioStateBehatExtension;
+
+use Behat\Testwork\Argument\ArgumentOrganiser;
+use Doctrine\Common\Annotations\Reader;
+use Gorghoa\ScenarioStateBehatExtension\Annotation\ScenarioStateArgument;
+use Gorghoa\ScenarioStateBehatExtension\Context\Initializer\ScenarioStateInitializer;
+use Prophecy\Prophecy\ObjectProphecy;
+
+/**
+ * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ */
+class ScenarioStateArgumentOrganiserTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ScenarioStateArgumentOrganiser
+     */
+    private $organiser;
+
+    /**
+     * @var ObjectProphecy|ArgumentOrganiser
+     */
+    private $organiserMock;
+
+    /**
+     * @var ObjectProphecy|ScenarioStateInitializer
+     */
+    private $initializerMock;
+
+    /**
+     * @var ObjectProphecy|ScenarioStateInterface
+     */
+    private $storeMock;
+
+    /**
+     * @var ObjectProphecy|\ReflectionMethod
+     */
+    private $functionMock;
+
+    /**
+     * @var ObjectProphecy|Reader
+     */
+    private $readerMock;
+
+    /**
+     * @var ObjectProphecy|ScenarioStateArgument
+     */
+    private $annotationMock;
+
+    protected function setUp()
+    {
+        $this->organiserMock = $this->prophesize(ArgumentOrganiser::class);
+        $this->initializerMock = $this->prophesize(ScenarioStateInitializer::class);
+        $this->storeMock = $this->prophesize(ScenarioStateInterface::class);
+        $this->functionMock = $this->prophesize(\ReflectionMethod::class);
+        $this->readerMock = $this->prophesize(Reader::class);
+        $this->annotationMock = $this->prophesize(ScenarioStateArgument::class);
+
+        $this->organiser = new ScenarioStateArgumentOrganiser(
+            $this->organiserMock->reveal(),
+            $this->initializerMock->reveal(),
+            $this->readerMock->reveal()
+        );
+    }
+
+    public function testOrganiseArguments()
+    {
+        $this->functionMock->getParameters()->willReturn([
+            (object)['name' => 'scenarioBanana'],
+            (object)['name' => 'gorilla'],
+            (object)['name' => 'foo'],
+        ])->shouldBeCalledTimes(1);
+
+        $this->initializerMock->getStore()->willReturn($this->storeMock->reveal())->shouldBeCalledTimes(1);
+        $this->readerMock->getMethodAnnotations($this->functionMock->reveal())->willReturn([
+            $this->annotationMock->reveal(),
+            $this->annotationMock->reveal(),
+        ])->shouldBeCalledTimes(1);
+        $this->annotationMock->getArgument()
+            ->willReturn('scenarioBanana', 'scenarioBanana', 'gorilla', 'gorilla')
+            ->shouldBeCalled();
+        $this->annotationMock->getName()
+            ->willReturn('scenarioBanana', 'scenarioBanana', 'scenarioBanana', 'scenarioGorilla', 'scenarioGorilla', 'scenarioGorilla')
+            ->shouldBeCalled();
+        $this->storeMock->hasStateFragment('scenarioBanana')->willReturn(true)->shouldBeCalledTimes(1);
+        $this->storeMock->hasStateFragment('scenarioGorilla')->willReturn(true)->shouldBeCalledTimes(1);
+        $this->storeMock->hasStateFragment('foo')->shouldNotBeCalled();
+        $this->storeMock->getStateFragment('scenarioBanana')->willReturn('Yummy banana!')->shouldBeCalledTimes(2);
+        $this->storeMock->getStateFragment('scenarioGorilla')->willReturn('Bonobo')->shouldBeCalledTimes(2);
+        $this->storeMock->getStateFragment('foo')->shouldNotBeCalled();
+
+        $this->organiserMock->organiseArguments($this->functionMock->reveal(), [
+            0 => 'scenarioBanana',
+            1 => 'gorilla',
+            'scenarioBanana' => 'Yummy banana!',
+            2 => 'Yummy banana!',
+            'gorilla' => 'Bonobo',
+            3 => 'Bonobo',
+        ])->shouldBeCalledTimes(1);
+
+        $this->organiser->organiseArguments($this->functionMock->reveal(), ['scenarioBanana', 'gorilla']);
+    }
+}


### PR DESCRIPTION
Fix #7 & #12

This PR changes method argument injection: to inject arguments from store to method declaration, this annotation **must be used**, otherwise arguments won't be injected.

``` php
/**
 * @ScenarioStateArgument("scenarioBanana")
 */
public function foo($scenarioBanana)
{
    // ...
}
```

``` php
/**
 * @ScenarioStateArgument(name="scenarioBanana")
 */
public function foo($scenarioBanana)
{
    // ...
}
```

``` php
/**
 * @ScenarioStateArgument(name="scenarioBanana", argument="banana")
 */
public function foo($banana)
{
    // ...
}
```
