### PR TITLE
Add missing docblocks to allow IDEs to autocomplete

### DIFF
--- a/src/Context/ScenarioStateAwareTrait.php
+++ b/src/Context/ScenarioStateAwareTrait.php
@@ -18,6 +18,9 @@ use Gorghoa\ScenarioStateBehatExtension\ScenarioStateInterface;
  */
 trait ScenarioStateAwareTrait
 {
+    /**
+     * @var ScenarioStateInterface
+     */
     private $scenarioState;
 
     /**

--- a/src/ScenarioState.php
+++ b/src/ScenarioState.php
@@ -16,6 +16,9 @@ namespace Gorghoa\ScenarioStateBehatExtension;
  */
 class ScenarioState implements ScenarioStateInterface
 {
+    /**
+     * @var array
+     */
     private $store = [];
 
     /**

--- a/src/ScenarioStateArgumentOrganiser.php
+++ b/src/ScenarioStateArgumentOrganiser.php
@@ -23,8 +23,19 @@ use ReflectionFunctionAbstract;
  */
 final class ScenarioStateArgumentOrganiser implements ArgumentOrganiser
 {
+    /**
+     * @var ArgumentOrganiser
+     */
     private $baseOrganiser;
+
+    /**
+     * @var ScenarioStateInitializer
+     */
     private $store;
+
+    /**
+     * @var Reader
+     */
     private $reader;
 
     public function __construct(ArgumentOrganiser $organiser, ScenarioStateInitializer $store, Reader $reader)

--- a/testapp/features/bootstrap/FeatureContext.php
+++ b/testapp/features/bootstrap/FeatureContext.php
@@ -32,6 +32,9 @@ class FeatureContext implements ScenarioStateAwareContext
      */
     private $scenarioState;
 
+    /**
+     * @param ScenarioStateInterface $scenarioState
+     */
     public function setScenarioState(ScenarioStateInterface $scenarioState)
     {
         $this->scenarioState = $scenarioState;


### PR DESCRIPTION
This is a simple PR which only add the missing docblocks so that IDEs such as PhpStorm, etc will be able to autocomplete while using the `scenarioState` trait.

Example:
<img width="654" alt="screen shot 2016-11-15 at 13 58 33" src="https://cloud.githubusercontent.com/assets/6195629/20308402/a9e824ac-ab3b-11e6-86f0-bf81337a4d43.png">
