### PR TITLE
Throw exception when asked for missing state

### DIFF
--- a/src/ScenarioState.php
+++ b/src/ScenarioState.php
@@ -10,6 +10,7 @@
  */
 
 namespace Gorghoa\ScenarioStateBehatExtension;
+
 use Gorghoa\ScenarioStateBehatExtension\ScenarioState\Exception\MissingStateException;
 
 /**

--- a/src/ScenarioState.php
+++ b/src/ScenarioState.php
@@ -39,6 +39,7 @@ class ScenarioState implements ScenarioStateInterface
         if (!$this->hasStateFragment($key)) {
             throw new MissingStateException("Missing {$key} state fragment was requested from store.");
         }
+
         return $this->store[$key];
     }
 

--- a/src/ScenarioState.php
+++ b/src/ScenarioState.php
@@ -10,6 +10,7 @@
  */
 
 namespace Gorghoa\ScenarioStateBehatExtension;
+use Gorghoa\ScenarioStateBehatExtension\ScenarioState\Exception\MissingStateException;
 
 /**
  * @author Rodrigue Villetard <rodrigue.villetard@gmail.com>
@@ -26,7 +27,7 @@ class ScenarioState implements ScenarioStateInterface
      */
     public function hasStateFragment($key)
     {
-        return isset($this->store[$key]);
+        return array_key_exists($key, $this->store);
     }
 
     /**
@@ -34,6 +35,9 @@ class ScenarioState implements ScenarioStateInterface
      */
     public function getStateFragment($key)
     {
+        if (!$this->hasStateFragment($key)) {
+            throw new MissingStateException("Missing {$key} state fragment was requested from store.");
+        }
         return $this->store[$key];
     }
 

--- a/src/ScenarioState/Exception/MissingStateException.php
+++ b/src/ScenarioState/Exception/MissingStateException.php
@@ -10,9 +10,8 @@
 namespace Gorghoa\ScenarioStateBehatExtension\ScenarioState\Exception;
 
 /**
- * Class MissingStateException
- * @package Gorghoa\ScenarioStateBehatExtension\ScenarioState\Exception
+ * @author Walter Dolce <walterdolce@gmail.com>
  */
-class MissingStateException extends \Exception
+class MissingStateException extends \LogicException
 {
 }

--- a/src/ScenarioState/Exception/MissingStateException.php
+++ b/src/ScenarioState/Exception/MissingStateException.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * This file is part of the ScenarioStateBehatExtension project.
+ *
+ * (c) Rodrigue Villetard <rodrigue.villetard@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Gorghoa\ScenarioStateBehatExtension\ScenarioState\Exception;
+
+/**
+ * Class MissingStateException
+ * @package Gorghoa\ScenarioStateBehatExtension\ScenarioState\Exception
+ */
+class MissingStateException extends \Exception
+{
+}

--- a/src/ScenarioStateInterface.php
+++ b/src/ScenarioStateInterface.php
@@ -10,6 +10,7 @@
  */
 
 namespace Gorghoa\ScenarioStateBehatExtension;
+use Gorghoa\ScenarioStateBehatExtension\ScenarioState\Exception\MissingStateException;
 
 /**
  * @author Rodrigue Villetard <rodrigue.villetard@gmail.com>
@@ -24,7 +25,7 @@ interface ScenarioStateInterface
 
     /**
      * @param string $key
-     *
+     * @throws MissingStateException
      * @return mixed
      */
     public function getStateFragment($key);

--- a/tests/ScenarioStateTest.php
+++ b/tests/ScenarioStateTest.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is part of the ScenarioStateBehatExtension project.
+ *
+ * (c) Rodrigue Villetard <rodrigue.villetard@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Gorghoa\ScenarioStateBehatExtension;
+
+use Gorghoa\ScenarioStateBehatExtension\ScenarioState\Exception\MissingStateException;
+
+/**
+ * Class ScenarioStateTest
+ * @package Gorghoa\ScenarioStateBehatExtension
+ */
+class ScenarioStateTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItThrowsExceptionWhenStateIsMissing()
+    {
+        $this->setExpectedException(MissingStateException::class);
+        $scenarioState = new ScenarioState();
+        $scenarioState->getStateFragment('not_existing_state');
+    }
+}

--- a/tests/ScenarioStateTest.php
+++ b/tests/ScenarioStateTest.php
@@ -20,7 +20,6 @@ class ScenarioStateTest extends \PHPUnit_Framework_TestCase
     public function testItThrowsExceptionWhenStateIsMissing()
     {
         $this->setExpectedException(MissingStateException::class);
-        $scenarioState = new ScenarioState();
-        $scenarioState->getStateFragment('not_existing_state');
+        (new ScenarioState())->getStateFragment('not_existing_state');
     }
 }

--- a/tests/ScenarioStateTest.php
+++ b/tests/ScenarioStateTest.php
@@ -12,8 +12,7 @@ namespace Gorghoa\ScenarioStateBehatExtension;
 use Gorghoa\ScenarioStateBehatExtension\ScenarioState\Exception\MissingStateException;
 
 /**
- * Class ScenarioStateTest
- * @package Gorghoa\ScenarioStateBehatExtension
+ * @author Walter Dolce <walterdolce@gmail.com>
  */
 class ScenarioStateTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Implementation for #18.

Note the change in `hasStateFragment`. This is because PHP might give you a `false` even though you actually have the key set. Please see https://eval.in/678234. 