### PR TITLE
php version >=7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,30 +7,29 @@ cache:
         - $HOME/.composer/cache
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
     - 7.0
     - 7.1
+    - 7.2
+    - 7.3
+    - 7.4
 
 matrix:
     fast_finish: true
-    allow_failures:
-        - php: 5.3
-        - php: 5.4
     include:
-        - php: 5.5
-        - php: 5.5
-          env: PREFER_LOWEST="--prefer-lowest"
-        - php: 5.6
-        - php: 5.6
-          env: PREFER_LOWEST="--prefer-lowest"
         - php: 7.0
         - php: 7.0
           env: PREFER_LOWEST="--prefer-lowest"
         - php: 7.1
         - php: 7.1
+          env: PREFER_LOWEST="--prefer-lowest"
+        - php: 7.2
+        - php: 7.2
+          env: PREFER_LOWEST="--prefer-lowest"
+        - php: 7.3
+        - php: 7.3
+          env: PREFER_LOWEST="--prefer-lowest"
+        - php: 7.4
+        - php: 7.4
           env: PREFER_LOWEST="--prefer-lowest"
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
 
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.0",
         "behat/behat": "^3.0.12",
         "symfony/dependency-injection": "^2.7|^3.0|^4.0",
         "symfony/process": "^2.0|^3.0|^4.0",


### PR DESCRIPTION
Set minimum php version to 7.0.

Builds on php 5 are failing and I don’t see the point to take time to maintain them.