### PR TITLE
Allow php5 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     allow_failures:
         - php: 5.3
         - php: 5.4
+        - php: 5.5
+        - php: 5.6
     include:
         - php: 5.5
         - php: 5.5


### PR DESCRIPTION
Travis’ builds are failing on php5, blocking some useful PR.

Allowing them to fail.